### PR TITLE
[#11] Icon 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vanilla-extract/css": "^1.17.1",
     "@vanilla-extract/recipes": "^0.5.5",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.488.0",
     "next": "15.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/features/common/components/Icon/Icon.spec.tsx
+++ b/src/features/common/components/Icon/Icon.spec.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Icon } from '.'
+
+describe('Icon 컴포넌트', () => {
+  it('기본 아이콘이 정상적으로 렌더링되어야 한다', () => {
+    render(
+      <Icon
+        name='Heart'
+        data-testid='test-icon'
+      />
+    )
+
+    const icon = screen.getByTestId('test-icon')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveAttribute('width', '24')
+    expect(icon).toHaveAttribute('height', '24')
+  })
+
+  it('크기가 지정된 아이콘이 정상적으로 렌더링되어야 한다', () => {
+    const size = 32
+    render(
+      <Icon
+        data-testid='test-icon'
+        name='Star'
+        size={size}
+      />
+    )
+
+    const icon = screen.getByTestId('test-icon')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveAttribute('width', size.toString())
+    expect(icon).toHaveAttribute('height', size.toString())
+  })
+
+  it('색상이 지정된 아이콘이 정상적으로 렌더링되어야 한다', () => {
+    const color = '#FF6B6B'
+    render(
+      <Icon
+        data-testid='test-icon'
+        name='Heart'
+        color={color}
+      />
+    )
+
+    const icon = screen.getByTestId('test-icon')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveAttribute('stroke', color)
+  })
+
+  it('모든 props가 지정된 아이콘이 정상적으로 렌더링되어야 한다', () => {
+    const props = {
+      name: 'Star' as const,
+      size: 40,
+      color: '#FFD700',
+      strokeWidth: 2.5
+    }
+
+    render(
+      <Icon
+        data-testid='test-icon'
+        {...props}
+      />
+    )
+
+    const icon = screen.getByTestId('test-icon')
+    expect(icon).toBeInTheDocument()
+    expect(icon).toHaveAttribute('width', props.size.toString())
+    expect(icon).toHaveAttribute('height', props.size.toString())
+    expect(icon).toHaveAttribute('stroke', props.color)
+    expect(icon).toHaveAttribute('stroke-width', props.strokeWidth.toString())
+  })
+})

--- a/src/features/common/components/Icon/Icon.stories.tsx
+++ b/src/features/common/components/Icon/Icon.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Icon } from '.'
+import { icons } from 'lucide-react'
+const meta = {
+  title: 'Common/Icon',
+  component: Icon,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'select',
+      options: Object.keys(icons)
+    },
+    size: {
+      control: { type: 'number' }
+    },
+    color: {
+      control: 'color'
+    }
+  }
+} satisfies Meta<typeof Icon>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    name: 'Heart',
+    size: 24
+  }
+}
+
+export const ColoredIcon: Story = {
+  args: {
+    name: 'Star',
+    color: '#FFD700',
+    size: 32
+  }
+}
+
+export const IconGroup: Story = {
+  args: {
+    name: 'Heart'
+  },
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
+      <Icon
+        name='Heart'
+        color='#FF6B6B'
+      />
+      <Icon
+        name='Star'
+        color='#FFD700'
+        size={32}
+      />
+      <Icon
+        name='Sun'
+        color='#FFA500'
+        size={40}
+      />
+      <Icon
+        name='Moon'
+        color='#6C5CE7'
+      />
+      <Icon
+        name='Github'
+        size={36}
+      />
+    </div>
+  )
+}

--- a/src/features/common/components/Icon/index.tsx
+++ b/src/features/common/components/Icon/index.tsx
@@ -1,0 +1,23 @@
+import { type LucideProps, icons } from 'lucide-react'
+
+interface IconProps extends Omit<LucideProps, 'icon'> {
+  name: keyof typeof icons
+  size?: number
+  color?: string
+}
+
+export function Icon({ name, size = 24, color, ...props }: IconProps) {
+  const IconComponent = icons[name]
+
+  if (!IconComponent) {
+    throw new Error(`Icon with name ${name} not found`)
+  }
+
+  return (
+    <IconComponent
+      size={size}
+      color={color}
+      {...props}
+    />
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2982,6 +2982,7 @@ __metadata:
     husky: "npm:^9.1.7"
     jsdom: "npm:^26.1.0"
     lint-staged: "npm:^15.5.1"
+    lucide-react: "npm:^0.488.0"
     next: "npm:15.3.0"
     playwright: "npm:^1.51.1"
     prettier: "npm:^3.5.3"
@@ -5506,6 +5507,15 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
+  languageName: node
+  linkType: hard
+
+"lucide-react@npm:^0.488.0":
+  version: 0.488.0
+  resolution: "lucide-react@npm:0.488.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/076eab8084a2febdab792cfd9511702643d6af506f7b46e7be2997ccc3a8f5a9c95b03f8e9dcecfbb75822811ff7d425b90aa6d0cf3d86b9994a18ca4d45a146
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- 연관된 이슈 번호를 작성해주세요. PR이 머지되면 자동으로 이슈가 닫힙니다. -->
close #11

## 📝 작업 내용
### 1. Icon 컴포넌트 개발
Lucide React의 아이콘을 쉽게 사용할 수 있는 Icon 컴포넌트를 개발했습니다 🎨

```typescript
interface IconProps extends Omit<LucideProps, 'icon'> {
  name: keyof typeof icons  // 타입 안정성을 위해 실제 존재하는 아이콘 이름만 허용
  size?: number
  color?: string
}
```

다음과 같은 기능들을 구현했습니다.
- 문자열로 아이콘 이름을 지정하여 간편하게 사용 가능 (`<Icon name="Heart" />`)
- 기본 크기는 24px로 설정
- 색상은 SVG의 stroke 속성으로 적용
- TypeScript를 통한 타입 안정성 확보 ✨

### 2. 테스트 및 스토리북 구현
#### 테스트
- 기본 렌더링 테스트
- 크기 변경 테스트
- 색상 적용 테스트
- 모든 props 조합 테스트

#### 스토리북
- 기본 아이콘 스토리
- 색상이 적용된 아이콘 스토리
- 다양한 크기와 색상을 보여주는 아이콘 그룹 스토리
- 모든 Lucide 아이콘을 선택할 수 있는 컨트롤 추가

사용 예시:
```tsx
// 기본 사용
<Icon name="Heart" />

// 크기와 색상 지정
<Icon name="Star" size={32} color="#FFD700" />

// stroke 두께 조절
<Icon name="Sun" strokeWidth={2.5} />
```
