### PR TITLE
[#15] 텍스트 버튼 추가

### DIFF
--- a/src/features/common/components/TextButton/TextButton.spec.tsx
+++ b/src/features/common/components/TextButton/TextButton.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TextButton } from '.'
+
+describe('TextButton', () => {
+  it('renders text button with text', () => {
+    render(<TextButton>Click me</TextButton>)
+    expect(screen.getByText('Click me')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    render(<TextButton className='custom-class'>Button</TextButton>)
+    expect(screen.getByText('Button')).toHaveClass('custom-class')
+  })
+
+  it('handles click events', async () => {
+    const handleClick = vi.fn()
+    render(<TextButton onClick={handleClick}>Click me</TextButton>)
+
+    const button = screen.getByText('Click me')
+    await button.click()
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/common/components/TextButton/TextButton.stories.tsx
+++ b/src/features/common/components/TextButton/TextButton.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { TextButton } from '.'
+
+const meta = {
+  title: 'Common/TextButton',
+  component: TextButton,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary']
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'medium', 'large']
+    },
+    onClick: { action: 'clicked' },
+    className: {
+      control: 'text'
+    },
+    children: {
+      control: 'text'
+    },
+    fit: {
+      control: 'boolean'
+    }
+  }
+} satisfies Meta<typeof TextButton>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: (args) => <TextButton {...args}>기본 버튼</TextButton>
+}
+
+export const SizeWithVariant: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <TextButton
+          size='small'
+          variant='primary'>
+          <TextButton.Txt>기본 버튼</TextButton.Txt>
+        </TextButton>
+        <TextButton
+          size='medium'
+          variant='primary'>
+          <TextButton.Txt>기본 버튼</TextButton.Txt>
+        </TextButton>
+        <TextButton
+          size='large'
+          variant='primary'>
+          <TextButton.Txt>기본 버튼</TextButton.Txt>
+        </TextButton>
+      </div>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <TextButton
+          size='small'
+          variant='secondary'>
+          <TextButton.Txt>기본 버튼</TextButton.Txt>
+        </TextButton>
+        <TextButton
+          size='medium'
+          variant='secondary'>
+          <TextButton.Txt>기본 버튼</TextButton.Txt>
+        </TextButton>
+        <TextButton
+          size='large'
+          variant='secondary'>
+          <TextButton.Txt>기본 버튼</TextButton.Txt>
+        </TextButton>
+      </div>
+    </div>
+  )
+}
+
+export const WithIcon: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <TextButton
+        leftAddon={
+          <TextButton.Icon
+            size={args.size}
+            name='Plus'
+          />
+        }
+        {...args}>
+        <TextButton.Txt
+          size={args.size}
+          variant={args.variant}>
+          기본 버튼
+        </TextButton.Txt>
+      </TextButton>
+      <TextButton
+        leftAddon={
+          <TextButton.Icon
+            size={args.size}
+            name='Plus'
+          />
+        }
+        rightAddon={
+          <TextButton.Icon
+            size={args.size}
+            name='Plus'
+          />
+        }
+        {...args}>
+        <TextButton.Txt
+          size={args.size}
+          variant={args.variant}>
+          기본 버튼
+        </TextButton.Txt>
+      </TextButton>
+    </div>
+  )
+}

--- a/src/features/common/components/TextButton/compound/Icon.tsx
+++ b/src/features/common/components/TextButton/compound/Icon.tsx
@@ -1,0 +1,28 @@
+import { type Txt } from '@/features/common/components/Typography'
+import { type ComponentProps } from 'react'
+import { useTextButtonContext } from '../context'
+import { Icon, type IconName } from '../../Icon'
+
+type TextButtonIconProps = ComponentProps<typeof Txt> & {
+  size?: 'small' | 'medium' | 'large'
+  name: IconName
+}
+
+export const TextButtonIcon = ({ size: propSize, name, ...restProps }: TextButtonIconProps) => {
+  const { size: ctxSize } = useTextButtonContext()
+  const size = propSize ?? ctxSize
+
+  return (
+    <Icon
+      size={ICON_SIZE_MAP[size]}
+      name={name}
+      {...restProps}
+    />
+  )
+}
+
+const ICON_SIZE_MAP = {
+  small: 18,
+  medium: 21,
+  large: 24
+} as const

--- a/src/features/common/components/TextButton/compound/Txt.tsx
+++ b/src/features/common/components/TextButton/compound/Txt.tsx
@@ -1,0 +1,37 @@
+import { Txt } from '@/features/common/components/Typography'
+import { type ComponentProps } from 'react'
+import { useTextButtonContext } from '../context'
+
+type TextButtonTxtProps = ComponentProps<typeof Txt> & {
+  size?: 'small' | 'medium' | 'large'
+  variant?: 'primary' | 'secondary'
+}
+
+export const TextButtonTxt = ({
+  size: propSize,
+  variant: propVariant,
+  ...restProps
+}: TextButtonTxtProps) => {
+  const { size: ctxSize, variant: ctxVariant } = useTextButtonContext()
+  const variant = propVariant ?? ctxVariant
+  const size = propSize ?? ctxSize
+
+  return (
+    <Txt
+      fontSize={TXT_SIZE_MAP[size]}
+      color={TXT_COLOR_MAP[variant]}
+      {...restProps}
+    />
+  )
+}
+
+const TXT_SIZE_MAP = {
+  small: 'caption',
+  medium: 'bodySm',
+  large: 'body'
+} as const
+
+const TXT_COLOR_MAP = {
+  primary: 'white90',
+  secondary: 'textSecondary'
+} as const

--- a/src/features/common/components/TextButton/context.tsx
+++ b/src/features/common/components/TextButton/context.tsx
@@ -1,0 +1,16 @@
+import { createCtxProvider } from '@/utils/createContextProvider'
+
+type TextButtonContextValue = {
+  size: 'small' | 'medium' | 'large'
+  variant: 'primary' | 'secondary'
+}
+
+const [TextButtonContextProvider, useTextButtonContext] = createCtxProvider<TextButtonContextValue>(
+  'TextButton',
+  {
+    size: 'medium',
+    variant: 'primary'
+  }
+)
+
+export { TextButtonContextProvider, useTextButtonContext }

--- a/src/features/common/components/TextButton/index.tsx
+++ b/src/features/common/components/TextButton/index.tsx
@@ -1,0 +1,44 @@
+import { type ButtonHTMLAttributes } from 'react'
+import { textButtonRecipe, type TextButtonProps } from './style.css'
+import { clsx } from 'clsx'
+import { TextButtonContextProvider } from './context'
+import { TextButtonTxt } from './compound/Txt'
+import { TextButtonIcon } from './compound/Icon'
+type TextButtonImplProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  TextButtonProps & {
+    leftAddon?: React.ReactNode
+    rightAddon?: React.ReactNode
+  }
+
+const TextButtonImpl = ({
+  children,
+  variant = 'primary',
+  size = 'medium',
+  className = '',
+  leftAddon,
+  rightAddon,
+  fit = false,
+  ...props
+}: TextButtonImplProps) => {
+  const hasAddon = !!leftAddon || !!rightAddon
+
+  return (
+    <TextButtonContextProvider
+      size={size}
+      variant={variant}>
+      <button
+        className={clsx(textButtonRecipe({ variant, size, hasAddon, fit }), className)}
+        type='button'
+        {...props}>
+        {leftAddon && leftAddon}
+        {children}
+        {rightAddon && rightAddon}
+      </button>
+    </TextButtonContextProvider>
+  )
+}
+
+export const TextButton = Object.assign(TextButtonImpl, {
+  Txt: TextButtonTxt,
+  Icon: TextButtonIcon
+})

--- a/src/features/common/components/TextButton/style.css.ts
+++ b/src/features/common/components/TextButton/style.css.ts
@@ -1,0 +1,68 @@
+import { recipe, type RecipeVariants } from '@vanilla-extract/recipes'
+import { vars } from '@/styles/theme.css'
+
+export const textButtonRecipe = recipe({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: vars.fontSize.sm,
+    fontWeight: vars.fontWeight.medium,
+    lineHeight: vars.lineHeight.snug,
+    transition: 'all 150ms ease-in-out',
+    cursor: 'pointer',
+    ':disabled': {
+      opacity: 0.5,
+      cursor: 'not-allowed'
+    }
+  },
+  variants: {
+    size: {
+      small: {
+        height: '2rem',
+        fontSize: vars.fontSize.sm
+      },
+      medium: {
+        height: '2.5rem',
+        fontSize: vars.fontSize.sm
+      },
+      large: {
+        height: '3rem',
+        fontSize: vars.fontSize.sm
+      }
+    },
+    variant: {
+      primary: {
+        color: vars.colors.textPrimary
+      },
+      secondary: {
+        color: vars.colors.textSecondary
+      }
+    },
+    hasAddon: {
+      true: {
+        padding: '0.5rem 0.75rem',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: vars.space.small
+      },
+      false: {
+        padding: '0.5rem 1rem'
+      }
+    },
+    fit: {
+      true: {
+        width: 'fit-content',
+        padding: 0,
+        height: 'fit-content'
+      }
+    }
+  },
+  defaultVariants: {
+    size: 'medium',
+    variant: 'primary'
+  }
+})
+
+export type TextButtonProps = RecipeVariants<typeof textButtonRecipe>


### PR DESCRIPTION
## 🔗 연관 이슈
close #14

## 📝 작업 내용

기존 Button 컴포넌트와 유사하지만 텍스트 스타일에 특화된 TextButton 컴포넌트를 추가했습니다.

### 구현 내용
- 크기(small, medium, large)와 변형(primary, secondary) 옵션 지원
- Compound 컴포넌트 패턴 적용 (TextButton.Txt, TextButton.Icon)
- 좌/우 애드온(leftAddon, rightAddon) 지원
- fit 속성을 통한 컨텐츠 기반 크기 조절
- 테스트 및 스토리북 문서화 추가

### 사용 예시
```tsx
<TextButton size="medium" variant="primary">
  <TextButton.Txt>버튼 텍스트</TextButton.Txt>
</TextButton>
```