### PR TITLE
[#13] 푸터 컴포넌트 추가

### DIFF
--- a/src/features/common/components/Footer/Footer.spec.tsx
+++ b/src/features/common/components/Footer/Footer.spec.tsx
@@ -1,0 +1,38 @@
+// src/features/common/components/Footer/Footer.spec.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Footer } from './Footer'
+import { Icon } from '../Icon'
+import { Txt } from '../Typography'
+import { Flex } from '../Flex'
+
+describe('Footer', () => {
+  it('children을 렌더링한다', () => {
+    const testContent = 'Footer Content'
+    render(<Footer>{testContent}</Footer>)
+
+    expect(screen.getByText(testContent)).toBeInTheDocument()
+  })
+
+  it('기본 스토리북 예시처럼 렌더링된다', () => {
+    render(
+      <Footer>
+        <Flex
+          align='center'
+          gap={4}>
+          <Icon
+            data-testid='copyright-icon'
+            role='img'
+            size={16}
+            name='Copyright'
+          />
+          <Txt size='bodySm'>Dev Notes</Txt>
+        </Flex>
+      </Footer>
+    )
+
+    expect(screen.getByText('Dev Notes')).toBeInTheDocument()
+    const copyrightIcon = screen.getByTestId('copyright-icon')
+    expect(copyrightIcon).toHaveClass('lucide', 'lucide-copyright')
+  })
+})

--- a/src/features/common/components/Footer/Footer.stories.tsx
+++ b/src/features/common/components/Footer/Footer.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Footer } from './Footer'
+import { Icon } from '../Icon'
+import { Txt } from '../Typography'
+import { Flex } from '../Flex'
+const meta = {
+  title: 'Common/Footer',
+  component: Footer,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof Footer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    label: (
+      <Flex
+        align='center'
+        gap={4}>
+        <Icon
+          size={16}
+          name='Copyright'
+        />
+        <Txt size='bodySm'>Dev Notes</Txt>
+      </Flex>
+    )
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: '100vw',
+          maxWidth: '1200px',
+          margin: '0 auto',
+          height: '100%'
+        }}>
+        <Story />
+      </div>
+    )
+  ],
+  render: (args) => <Footer {...args} />
+}

--- a/src/features/common/components/Footer/Footer.stories.tsx
+++ b/src/features/common/components/Footer/Footer.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    label: (
+    children: (
       <Flex
         align='center'
         gap={4}>

--- a/src/features/common/components/Footer/Footer.tsx
+++ b/src/features/common/components/Footer/Footer.tsx
@@ -1,13 +1,12 @@
 import { type CommonProps } from '@/types/common'
-import { Txt } from '../Typography'
 import clsx from 'clsx'
 import * as styles from './style.css'
 import { Flex } from '../Flex'
-export interface FooterProps extends CommonProps {
-  label: React.ReactNode
-}
+import { type ComponentProps } from 'react'
 
-export function Footer({ label, className: classNameFromProps, ...props }: FooterProps) {
+export type FooterProps = CommonProps & ComponentProps<'footer'>
+
+export function Footer({ children, className: classNameFromProps, ...props }: FooterProps) {
   return (
     <Flex
       asChild
@@ -16,7 +15,7 @@ export function Footer({ label, className: classNameFromProps, ...props }: Foote
       <footer
         className={clsx(styles.container, classNameFromProps)}
         {...props}>
-        <Txt size='bodySm'>{label}</Txt>
+        {children}
       </footer>
     </Flex>
   )

--- a/src/features/common/components/Footer/Footer.tsx
+++ b/src/features/common/components/Footer/Footer.tsx
@@ -1,0 +1,23 @@
+import { type CommonProps } from '@/types/common'
+import { Txt } from '../Typography'
+import clsx from 'clsx'
+import * as styles from './style.css'
+import { Flex } from '../Flex'
+export interface FooterProps extends CommonProps {
+  label: React.ReactNode
+}
+
+export function Footer({ label, className: classNameFromProps, ...props }: FooterProps) {
+  return (
+    <Flex
+      asChild
+      justify='center'
+      align='center'>
+      <footer
+        className={clsx(styles.container, classNameFromProps)}
+        {...props}>
+        <Txt size='bodySm'>{label}</Txt>
+      </footer>
+    </Flex>
+  )
+}

--- a/src/features/common/components/Footer/index.tsx
+++ b/src/features/common/components/Footer/index.tsx
@@ -1,0 +1,2 @@
+export { Footer } from './Footer'
+export type { FooterProps } from './Footer'

--- a/src/features/common/components/Footer/style.css.ts
+++ b/src/features/common/components/Footer/style.css.ts
@@ -1,0 +1,8 @@
+import { style } from '@vanilla-extract/css'
+import { vars } from '@/styles/theme.css'
+
+export const container = style({
+  width: '100%',
+  height: vars.height.footer,
+  backgroundColor: vars.colors.white90
+})


### PR DESCRIPTION
## 🔗 연관 이슈
close #13

## 📝 작업 내용
Footer 컴포넌트를 개발했습니다.

- Flex 컴포넌트를 활용한 중앙 정렬 레이아웃 구현
- 재사용 가능한 컴포넌트 설계 (children prop을 통한 유연한 콘텐츠 구성)
- vanilla-extract를 활용한 스타일링
- 테스트 코드 작성 완료

```tsx
<Footer>
  <Flex align="center" gap={4}>
    <Icon size={16} name="Copyright" />
    <Txt size="bodySm">Dev Notes</Txt>
  </Flex>
</Footer>
```