### PR TITLE
[#27] 컬러값 검사를 위한 playwright 테스트 추가

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,8 @@
 name: Playwright
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: ['main']
 
 jobs:
   test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,5 +12,10 @@ jobs:
           node-version: '20'
       - run: corepack enable
       - run: yarn install --immutable
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-browsers-${{ hashFiles('**/yarn.lock') }}
       - run: yarn playwright install --with-deps
       - run: yarn test:play

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,16 @@
+name: Playwright
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn playwright install --with-deps
+      - run: yarn test:play

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -45,9 +45,6 @@ jobs:
             
       - name: Install Dependencies
         run: yarn install --immutable
-
-      - name: Install Playwright Browsers
-        run: yarn playwright install --with-deps chromium
         
       - name: Cache Next.js build
         uses: actions/cache@v4
@@ -67,9 +64,3 @@ jobs:
         
       - name: Check Format
         run: yarn prettier --check .
-        
-      - name: Run Tests
-        run: yarn test --no-browser
-        
-      - name: Run Playwright Tests
-        run: yarn test:play

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -70,3 +70,6 @@ jobs:
         
       - name: Run Tests
         run: yarn test --no-browser
+        
+      - name: Run Playwright Tests
+        run: yarn test:play

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,4 +1,4 @@
-name: 'Blog Storybook Deployment'
+name: 'Storybook'
 
 on:
   pull_request:
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   chromatic:
-    name: 'Blog Storybook Deployment'
+    name: 'Storybook Deployment'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,0 +1,15 @@
+name: Vitest
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: corepack enable
+      - run: yarn install --immutable
+      - run: yarn test:vitest

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,6 +1,8 @@
 name: Vitest
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: ['main']
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ next-env.d.ts
 !.yarn/sdks
 !.yarn/versions
 *storybook.log
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-npx yarn build && npx yarn test

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "test:play": "playwright test",
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^3",
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.52.0",
     "@storybook/addon-essentials": "^8.6.12",
     "@storybook/addon-onboarding": "^8.6.12",
     "@storybook/blocks": "^8.6.12",
@@ -54,7 +56,6 @@
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
     "lint-staged": "^15.5.1",
-    "playwright": "^1.51.1",
     "prettier": "^3.5.3",
     "storybook": "^8.6.12",
     "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "typecheck": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "test:vitest": "vitest",
     "test:play": "playwright test",
     "chromatic": "chromatic --exit-zero-on-changes"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,12 +68,12 @@ export default defineConfig({
     //   name: 'Google Chrome',
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
-  ]
+  ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'yarn storybook',
+    url: 'http://localhost:6006',
+    reuseExistingServer: !process.env.CI
+  }
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './src/test',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry'
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] }
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ]
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+})

--- a/src/features/common/components/Typography/Typography.spec.tsx
+++ b/src/features/common/components/Typography/Typography.spec.tsx
@@ -24,7 +24,7 @@ describe('Typography', () => {
     expect(screen.getByText('본문').tagName).toBe('P')
   })
 
-  it('색상 변형을 적용한다', () => {
+  it('색상 변형을 클래스를 이용하여 확인한다', () => {
     const { container } = render(<Txt color={colorVariants.primary}>주요 텍스트</Txt>)
     const element = container.firstChild as HTMLElement
 
@@ -32,6 +32,25 @@ describe('Typography', () => {
 
     const classNames = element.className.split(' ')
     expect(classNames.some((className) => className.includes('_color_primary'))).toBe(true)
+  })
+
+  it('색상 변형을 jsdom 환경에서 className과 style 객체로 확인한다', () => {
+    /**
+     * - vanilla-extract는 빌드 타임에 CSS 파일을 만들고, className만 붙여준다.
+     * - jsdom은 CSS 파일을 파싱하지 않으므로, 실제 style 값(element.style.color 등)은 비어 있거나 기본값만 나온다.
+     * - emotion, styled-components는 <style> 태그를 동적으로 삽입하므로 jsdom에서도 getComputedStyle 등으로 어느 정도 스타일 확인이 가능하다.
+     * - 실제 스타일 값 검증이 필요하다면 E2E 테스트(Cypress, Playwright 등)에서 확인해야 한다.
+     *
+     * 참고: https://vanilla-extract.style/documentation/test-environments/
+     */
+    const { container } = render(<Txt color={colorVariants.primary}>주요 텍스트</Txt>)
+    const element = container.firstChild as HTMLElement
+
+    // className이 정상적으로 붙는지 확인
+    expect(element.className).toContain(colorVariants.primary)
+
+    // jsdom 환경에서는 style 값이 비어 있음을 확인
+    expect(element.style.color).toBe('')
   })
 
   it('추가 props를 전달한다', () => {

--- a/src/features/common/components/Typography/Typography.stories.tsx
+++ b/src/features/common/components/Typography/Typography.stories.tsx
@@ -97,8 +97,16 @@ export const Colors: Story = {
   },
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-      <Txt color={colorVariants.textPrimary}>주요 텍스트 색상 (textPrimary)</Txt>
-      <Txt color={colorVariants.textSecondary}>보조 텍스트 색상 (textSecondary)</Txt>
+      <Txt
+        data-testid='text-primary'
+        color={colorVariants.textPrimary}>
+        주요 텍스트 색상 (textPrimary)
+      </Txt>
+      <Txt
+        data-testid='text-secondary'
+        color={colorVariants.textSecondary}>
+        보조 텍스트 색상 (textSecondary)
+      </Txt>
     </div>
   )
 }

--- a/src/test/e2e/typography.sb.spec.ts
+++ b/src/test/e2e/typography.sb.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+
+test('Storybook에서 Txt 컴포넌트의 primary 컬러가 적용되는지 확인', async ({ page }) => {
+  // Storybook에서 Primary 스토리의 URL로 이동
+  await page.goto('http://localhost:6006/?path=/story/common-typography--colors')
+
+  // Storybook의 프리뷰 iframe을 찾음
+  const frame = page.frameLocator('iframe#storybook-preview-iframe')
+
+  // iframe 내부에서 텍스트로 요소 찾기
+  const element = frame.getByText('주요 텍스트 색상 (textPrimary)')
+
+  // 컬러값 추출
+  const color = await element.evaluate((el) => getComputedStyle(el).color)
+
+  // 기대하는 컬러값: #1b1c1d → rgb(27, 28, 29)
+  expect(color).toBe('rgb(27, 28, 29)')
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     include: ['**/*.spec.{ts,tsx}'],
-    exclude: ['node_modules', '.storybook/**/*', '**/*.stories.{ts,tsx}'],
+    exclude: ['node_modules', '.storybook/**/*', '**/*.stories.{ts,tsx}', 'src/test/e2e/**/*'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,6 +1267,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.52.0":
+  version: 1.52.0
+  resolution: "@playwright/test@npm:1.52.0"
+  dependencies:
+    playwright: "npm:1.52.0"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/1c428b421593eb4f79b7c99783a389c3ab3526c9051ec772749f4fca61414dfa9f2344eba846faac5f238084aa96c836364a91d81d3034ac54924f239a93e247
+  languageName: node
+  linkType: hard
+
 "@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
@@ -2954,6 +2965,7 @@ __metadata:
   dependencies:
     "@chromatic-com/storybook": "npm:^3"
     "@eslint/eslintrc": "npm:^3"
+    "@playwright/test": "npm:^1.52.0"
     "@radix-ui/react-slot": "npm:^1.2.0"
     "@storybook/addon-essentials": "npm:^8.6.12"
     "@storybook/addon-onboarding": "npm:^8.6.12"
@@ -2984,7 +2996,6 @@ __metadata:
     lint-staged: "npm:^15.5.1"
     lucide-react: "npm:^0.488.0"
     next: "npm:15.3.0"
-    playwright: "npm:^1.51.1"
     prettier: "npm:^3.5.3"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -6229,27 +6240,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.51.1":
-  version: 1.51.1
-  resolution: "playwright-core@npm:1.51.1"
+"playwright-core@npm:1.52.0":
+  version: 1.52.0
+  resolution: "playwright-core@npm:1.52.0"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/4f004d9dea5ecbd76b84c858fa4880ed955600b6cda972a3e8093ea47e150ce20bf2ea806e73e740497d34f4b61b080c208339a661fc75ad04d8f00bedcc21e0
+  checksum: 10c0/640945507e6ca2144e9f596b2a6ecac042c2fd3683ff99e6271e9a7b38f3602d415f282609d569456f66680aab8b3c5bb1b257d8fb63a7fc0ed648261110421f
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.51.1":
-  version: 1.51.1
-  resolution: "playwright@npm:1.51.1"
+"playwright@npm:1.52.0":
+  version: 1.52.0
+  resolution: "playwright@npm:1.52.0"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.51.1"
+    playwright-core: "npm:1.52.0"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/2aea553b8b1086ee419e72c9d4f4117686e6bdb5e09e0f47dfe563ce0f0bd79c4ee79dd9c8a0f023a2fb7803b81d4fdc552887410d16c036be07f21ab72b3f46
+  checksum: 10c0/2c6edf1e15e59bbaf77f3fa0fe0ac975793c17cff835d9c8b8bc6395a3b6f1c01898b3058ab37891b2e4d424bcc8f1b4844fe70d943e0143d239d7451408c579
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🔗 연관 이슈
<!-- 연관된 이슈 번호를 작성해주세요. PR이 머지되면 자동으로 이슈가 닫힙니다. -->
close #27

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
### Txt 컴포넌트의 스타일(특히 컬러) 테스트를 신뢰성 있게 분리
- jsdom 기반 유닛 테스트에서는 className이 정상적으로 붙는지, DOM 구조가 올바른지만 검증
- 실제 컬러값 등 스타일 값 검증은 Playwright + Storybook 기반 E2E 테스트로 분리
#### 이유
- `jsdom` 환경에서는 `vanilla-extract`, `Tailwind` 등 빌드 타임 CSS의 실제 스타일 값(`element.style.color` 등)을 검증할 수 없음
(`jsdom`은 `CSS` 파일을 파싱하지 않으므로, `className`만 붙고 `style` 값은 비어 있음)
- `emotion`, `styled-components` 등은 동적으로 `<style>` 태그를 삽입하므로 `jsdom`에서도 어느 정도 스타일 확인이 가능하지만, `vanilla-extrac`t는 그렇지 않음
- 실제 스타일 값이 적용되는지 신뢰성 있게 검증하려면 브라우저 환경에서 `getComputedStyle`로 값을 추출해야 하므로, `Playwright` `E2E` 테스트로 분리
참고: https://vanilla-extract.style/documentation/test-environments/
#### 작업 내역
- Typography.spec.tsx: jsdom 환경에서 className, DOM 구조 등만 검증하도록 수정
- typography.sb.spec.ts: Storybook에서 Txt 컴포넌트의 컬러값을 Playwright로 E2E 테스트

`playwright` 설치를 위해 기존에 설치되어 있던 `playwright` 설치를 제거후 다시 설치하였습니다.

`@playwright` 제거 후 `@playwright/test`를 설치.

## 💬 리뷰 요구사항(선택)
<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
--> 
