### PR TITLE
[#29] 칩 컴포넌트 구현

### DIFF
--- a/src/features/common/components/Chip/Chip.spec.tsx
+++ b/src/features/common/components/Chip/Chip.spec.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Chip } from './Chip'
+
+describe('Chip', () => {
+  it('children을 렌더링한다', () => {
+    render(<Chip>테스트 칩</Chip>)
+    expect(screen.getByText('테스트 칩')).toBeInTheDocument()
+  })
+
+  it('leftAddon을 렌더링한다', () => {
+    render(<Chip leftAddon={<span data-testid='left-addon'>L</span>}>칩</Chip>)
+    expect(screen.getByTestId('left-addon')).toBeInTheDocument()
+  })
+
+  it('rightAddon을 렌더링한다', () => {
+    render(<Chip rightAddon={<span data-testid='right-addon'>R</span>}>칩</Chip>)
+    expect(screen.getByTestId('right-addon')).toBeInTheDocument()
+  })
+
+  it('color prop이 적용된다', () => {
+    const { container } = render(<Chip color='primary'>컬러칩</Chip>)
+    const element = container.firstChild as HTMLElement
+    expect(element.className).toContain('primary')
+  })
+
+  it('size prop이 적용된다', () => {
+    const { container } = render(<Chip size='small'>사이즈칩</Chip>)
+    const element = container.firstChild as HTMLElement
+    expect(element.className).toContain('small')
+  })
+})

--- a/src/features/common/components/Chip/Chip.stories.tsx
+++ b/src/features/common/components/Chip/Chip.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Chip } from './Chip'
+
+const meta = {
+  title: 'Common/Chip',
+  component: Chip,
+  parameters: {
+    layout: 'centered'
+  },
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'white']
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'medium']
+    }
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof Chip>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    children: 'Chip',
+    color: 'primary',
+    size: 'medium'
+  }
+}

--- a/src/features/common/components/Chip/Chip.stories.tsx
+++ b/src/features/common/components/Chip/Chip.stories.tsx
@@ -30,3 +30,12 @@ export const Default: Story = {
     size: 'medium'
   }
 }
+
+export const WithIcon: Story = {
+  args: {
+    children: 'Chip',
+    color: 'primary',
+    size: 'medium',
+    leftAddon: <Chip.Icon name='Check' />
+  }
+}

--- a/src/features/common/components/Chip/Chip.tsx
+++ b/src/features/common/components/Chip/Chip.tsx
@@ -2,17 +2,18 @@ import { type ComponentProps, type ElementType } from 'react'
 import { If } from '../If'
 import * as style from './style.css'
 import clsx from 'clsx'
-import { type ChipRecipeProps } from './style.css'
+import { type ChipColor, type ChipSize } from './type'
+import { ChipIcon } from './compound/Icon'
+export type ChipProps = ComponentProps<'div'> & {
+  children: React.ReactNode
+  as?: ElementType
+  leftAddon?: React.ReactNode
+  rightAddon?: React.ReactNode
+  color?: ChipColor
+  size?: ChipSize
+}
 
-export type ChipProps = ComponentProps<'div'> &
-  ChipRecipeProps & {
-    children: React.ReactNode
-    as?: ElementType
-    leftAddon?: React.ReactNode
-    rightAddon?: React.ReactNode
-  }
-
-export const Chip = ({
+const ChipImpl = ({
   children,
   leftAddon,
   rightAddon,
@@ -38,3 +39,7 @@ export const Chip = ({
     </Component>
   )
 }
+
+export const Chip = Object.assign(ChipImpl, {
+  Icon: ChipIcon
+})

--- a/src/features/common/components/Chip/Chip.tsx
+++ b/src/features/common/components/Chip/Chip.tsx
@@ -1,0 +1,40 @@
+import { type ComponentProps, type ElementType } from 'react'
+import { If } from '../If'
+import * as style from './style.css'
+import clsx from 'clsx'
+import { type ChipRecipeProps } from './style.css'
+
+export type ChipProps = ComponentProps<'div'> &
+  ChipRecipeProps & {
+    children: React.ReactNode
+    as?: ElementType
+    leftAddon?: React.ReactNode
+    rightAddon?: React.ReactNode
+  }
+
+export const Chip = ({
+  children,
+  leftAddon,
+  rightAddon,
+  as: Component = 'div',
+  className: classNameFromProps,
+  color,
+  size = 'medium',
+  ...props
+}: ChipProps) => {
+  const hasLeftAddon = !!leftAddon
+  const hasRightAddon = !!rightAddon
+  return (
+    <Component
+      className={clsx(style.chipStyle({ color, size }), classNameFromProps)}
+      {...props}>
+      <If condition={hasLeftAddon}>
+        <div className={style.chipLeftAddonStyle}>{leftAddon}</div>
+      </If>
+      {children}
+      <If condition={hasRightAddon}>
+        <div className={style.chipRightAddonStyle}>{rightAddon}</div>
+      </If>
+    </Component>
+  )
+}

--- a/src/features/common/components/Chip/compound/Icon.tsx
+++ b/src/features/common/components/Chip/compound/Icon.tsx
@@ -1,0 +1,35 @@
+import { type ComponentProps } from 'react'
+import { useChipContext } from '../context'
+import { Icon } from '../../Icon'
+import { vars } from '@/styles/theme.css'
+import type { ChipColor } from '../type'
+type ChipIconProps = ComponentProps<typeof Icon> & {
+  color?: ChipColor
+}
+
+export const ChipIcon = (props: ChipIconProps) => {
+  const { size: sizeFromProps, color: colorFromProps, name, ...restProps } = props
+  const { size: ctxSize, variant: ctxVariant } = useChipContext('Chip.Icon')
+
+  const size = sizeFromProps ?? ICON_SIZE_MAP[ctxSize]
+  const variant = colorFromProps ?? ctxVariant
+  return (
+    <Icon
+      size={size}
+      color={ICON_COLOR_MAP[variant]}
+      name={name}
+      {...restProps}
+    />
+  )
+}
+
+const ICON_SIZE_MAP = {
+  small: 10,
+  medium: 14
+} as const
+
+const ICON_COLOR_MAP = {
+  primary: vars.colors.white100,
+  secondary: vars.colors.grey,
+  white: vars.colors.primary
+} as const

--- a/src/features/common/components/Chip/context.tsx
+++ b/src/features/common/components/Chip/context.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { createCtxProvider } from '@/utils/createContextProvider'
+import type { ChipSize, ChipColor } from './type'
+
+type ChipContextValue = {
+  size: ChipSize
+  variant: ChipColor
+}
+
+const [ChipContextProvider, useChipContext] = createCtxProvider<ChipContextValue>('Chip', {
+  size: 'medium',
+  variant: 'primary'
+})
+
+export { ChipContextProvider, useChipContext }

--- a/src/features/common/components/Chip/index.tsx
+++ b/src/features/common/components/Chip/index.tsx
@@ -1,0 +1,2 @@
+export { Chip } from './Chip'
+export type { ChipProps } from './Chip'

--- a/src/features/common/components/Chip/style.css.ts
+++ b/src/features/common/components/Chip/style.css.ts
@@ -1,0 +1,51 @@
+import { vars } from '@/styles/theme.css'
+import { style } from '@vanilla-extract/css'
+import { recipe, type RecipeVariants } from '@vanilla-extract/recipes'
+
+export const chipStyle = recipe({
+  base: {
+    borderRadius: vars.borderRadius.full
+  },
+  variants: {
+    color: {
+      primary: {
+        background: vars.colors.primary,
+        color: vars.colors.white100
+      },
+      secondary: {
+        background: vars.colors.grey,
+        color: vars.colors.textSecondary,
+        border: `1px solid ${vars.colors.borderLight}`
+      },
+      white: {
+        background: vars.colors.white100,
+        color: vars.colors.textPrimary,
+        border: `1px solid ${vars.colors.borderLight}`
+      }
+    },
+    size: {
+      small: {
+        padding: '2px 4px',
+        fontSize: vars.fontSize.xs
+      },
+      medium: {
+        padding: '4px 8px',
+        fontSize: vars.fontSize.sm
+      }
+    }
+  },
+  defaultVariants: {
+    color: 'primary',
+    size: 'medium'
+  }
+})
+
+export const chipLeftAddonStyle = style({
+  paddingRight: '4px'
+})
+
+export const chipRightAddonStyle = style({
+  paddingLeft: '4px'
+})
+
+export type ChipRecipeProps = RecipeVariants<typeof chipStyle>

--- a/src/features/common/components/Chip/style.css.ts
+++ b/src/features/common/components/Chip/style.css.ts
@@ -4,6 +4,9 @@ import { recipe, type RecipeVariants } from '@vanilla-extract/recipes'
 
 export const chipStyle = recipe({
   base: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     borderRadius: vars.borderRadius.full
   },
   variants: {
@@ -41,11 +44,11 @@ export const chipStyle = recipe({
 })
 
 export const chipLeftAddonStyle = style({
-  paddingRight: '4px'
+  paddingRight: '2px'
 })
 
 export const chipRightAddonStyle = style({
-  paddingLeft: '4px'
+  paddingLeft: '2px'
 })
 
 export type ChipRecipeProps = RecipeVariants<typeof chipStyle>

--- a/src/features/common/components/Chip/type.ts
+++ b/src/features/common/components/Chip/type.ts
@@ -1,0 +1,4 @@
+import { type Colors } from '@/styles/theme.css'
+
+export type ChipColor = Omit<Colors, 'primary' | 'white' | 'secondary'>
+export type ChipSize = 'small' | 'medium'

--- a/src/features/common/components/Chip/type.ts
+++ b/src/features/common/components/Chip/type.ts
@@ -1,4 +1,2 @@
-import { type Colors } from '@/styles/theme.css'
-
-export type ChipColor = Omit<Colors, 'primary' | 'white' | 'secondary'>
+export type ChipColor = 'primary' | 'secondary' | 'white'
 export type ChipSize = 'small' | 'medium'


### PR DESCRIPTION
## 🔗 연관 이슈
close #12

## 📝 작업 내용

Chip 컴포넌트의 테스트 코드를 추가 및 개선했습니다.

### 구현 내용
- children, leftAddon, rightAddon 렌더링 테스트 추가
- color, size prop이 className에 포함되는지 검사하는 테스트 추가
- vanilla-extract 환경에 맞는 className 기반 prop 적용 여부 확인

### 사용 예시
```tsx
<Chip color="primary" size="small" leftAddon="L" rightAddon="R">칩</Chip>)
